### PR TITLE
Add persistent key to Streamlit data editor

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -65,6 +65,7 @@ data = st.data_editor(
     st.session_state.table,
     num_rows="dynamic",
     use_container_width=True,
+    key="table_editor",
 )
 st.session_state.table = data
 


### PR DESCRIPTION
## Summary
- ensure Streamlit `st.data_editor` maintains state by adding a widget key

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4ab8197c883309d6e6e85bf14ac0d