### PR TITLE
Add cost of storage calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# 🎈 Blank app template
+# 🎈 Economic toolbox
 
-A simple Streamlit app template for you to modify!
+A Streamlit application featuring an Expected Annual Damage (EAD) calculator
+and a cost of storage calculator.
 
 [![Open in Streamlit](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://blank-app-template.streamlit.app/)
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -22,6 +22,16 @@ def ead_trapezoidal(prob, damages):
     )
 
 
+def storage_cost(quantity, unit_price, storage_rate, interest_rate, years):
+    """Compute total storage cost given rates and time."""
+    quantity = float(quantity)
+    unit_price = float(unit_price)
+    storage_rate = float(storage_rate)
+    interest_rate = float(interest_rate)
+    years = float(years)
+    return quantity * unit_price * (storage_rate + interest_rate) * years
+
+
 # ---------------------------------------------------------------------------
 # Data input section
 # ---------------------------------------------------------------------------
@@ -212,4 +222,20 @@ if st.button("Calculate EAD"):
                 )
             else:
                 st.success(f"{col} Expected Annual Damage: ${val:,.2f}")
+
+
+# ---------------------------------------------------------------------------
+# Cost of storage calculator
+# ---------------------------------------------------------------------------
+st.header("Cost of Storage Calculator")
+with st.form("storage_form"):
+    quantity = st.number_input("Quantity", min_value=0.0, value=100.0)
+    unit_price = st.number_input("Unit price", min_value=0.0, value=10.0)
+    storage_rate = st.number_input("Annual storage cost (%)", min_value=0.0, value=2.0) / 100
+    interest_rate = st.number_input("Annual interest rate (%)", min_value=0.0, value=5.0) / 100
+    years = st.number_input("Years in storage", min_value=0.0, value=1.0)
+    compute_storage = st.form_submit_button("Compute storage cost")
+if compute_storage:
+    cost = storage_cost(quantity, unit_price, storage_rate, interest_rate, years)
+    st.success(f"Total storage cost: ${cost:,.2f}")
 


### PR DESCRIPTION
## Summary
- add `storage_cost` helper and interactive Cost of Storage calculator section
- clarify README to mention new calculator alongside EAD tool

## Testing
- `pytest -q`
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4c204918c8330b14bdc0eae74c14e