### PR TITLE
Handle Streamlit data editor keyword issue

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -100,7 +100,6 @@ with st.form("data_table_form"):
         use_container_width=True,
         key="table_editor",
         column_config=column_config,
-        help="Edit frequency, damage, and optional stage values. Frequencies should be between 0 and 1.",
     )
     submitted = st.form_submit_button(
         "Save table", help="Apply edits to the table above."


### PR DESCRIPTION
## Summary
- Remove unsupported `help` parameter from `st.data_editor` call that caused TypeError

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4c532006083309c1dab3fe0725bd5