### PR TITLE
Add benefit-cost analysis module with references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # 🎈 Economic toolbox
 
-A Streamlit application featuring an Expected Annual Damage (EAD) calculator
-and an updated cost of storage calculator.
+A Streamlit application featuring an Expected Annual Damage (EAD) calculator,
+an updated cost of storage calculator, and a benefit–cost analysis module that
+accommodates additional project benefits (navigation, recreation, ecosystem
+restoration, water supply, etc.).
 
 [![Open in Streamlit](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://blank-app-template.streamlit.app/)
 
@@ -24,3 +26,4 @@ and an updated cost of storage calculator.
 - U.S. Army Corps of Engineers. (1996). *Engineering Manual 1110-2-1619: Risk-Based Analysis for Flood Damage Reduction Studies*.
 - U.S. Office of Management and Budget. (1992). *Circular A-94: Guidelines and Discount Rates for Benefit-Cost Analysis of Federal Programs*.
 - U.S. Army Corps of Engineers. Civil Works Construction Cost Index System (CWCCIS) and Engineering News Record (ENR) cost indexes.
+- U.S. Army Corps of Engineers. (2000). *Planning Guidance Notebook* (ER 1105-2-100).


### PR DESCRIPTION
## Summary
- add present value and benefit-cost analysis utilities following USACE/OMB guidance
- expand Streamlit app with benefit-cost analysis section supporting multiple benefit categories and discount rate selection
- document new capabilities and references in README

## Testing
- `python -m py_compile streamlit_app.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a61d6ab5888330a081aa9b2a497bc3