### PR TITLE
Handle Streamlit data editor help parameter incompatibility

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -358,6 +358,7 @@ if st.button(
     )
 
 with st.form("bca_table_form"):
+    st.caption("Enter annual costs and benefits in constant dollars.")
     bca_data = st.data_editor(
         st.session_state.bca_table,
         num_rows="dynamic",
@@ -372,7 +373,6 @@ with st.form("bca_table_form"):
                 if col.startswith("Benefit")
             },
         },
-        help="Enter annual costs and benefits in constant dollars.",
     )
     save_bca = st.form_submit_button("Save BCA table", help="Apply edits to the table above.")
 if save_bca:


### PR DESCRIPTION
## Summary
- Replace unsupported `help` parameter in Streamlit's `data_editor` with a caption to avoid TypeError

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6215e08588330b5568cd15b0b2d97