### PR TITLE
Replace benefit-cost analysis with project cost annualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # 🎈 Economic toolbox
 
 A Streamlit application featuring an Expected Annual Damage (EAD) calculator,
-an updated cost of storage calculator, and a benefit–cost analysis module that
-accommodates additional project benefits (navigation, recreation, ecosystem
-restoration, water supply, etc.).
+an updated cost of storage calculator, and a project cost annualizer that
+produces annualized construction costs and benefit–cost ratios.
 
 [![Open in Streamlit](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://blank-app-template.streamlit.app/)
 


### PR DESCRIPTION
## Summary
- remove legacy benefit-cost analysis module
- add project cost annualizer with interest during construction and capital recovery calculations
- document new annualizer in README

## Testing
- `python -m py_compile streamlit_app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a624c43bfc8330aecf19d7afb25e01