### PR TITLE
chore: simplify formulas in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,65 +27,61 @@ defined beneath each equation so results can be replicated by hand.
 
 ### Expected Annual Damage (EAD)
 
-\[
-\text{EAD} = \sum_{i=1}^{n-1} \tfrac{1}{2} (D_i + D_{i+1}) (P_i - P_{i+1})
-\]
+```
+EAD = sum from i = 1 to n - 1 of 0.5 * (D_i + D_{i+1}) * (P_i - P_{i+1})
+```
 
-where \(P_i\) are exceedance probabilities listed from 1 down to 0 and \(D_i\)
-are the corresponding damages. The summation applies the trapezoidal rule to
-integrate the damage–frequency curve.
+where P_i are exceedance probabilities listed from 1 down to 0 and D_i are the
+corresponding damages. The summation applies the trapezoidal rule to integrate
+the damage–frequency curve.
 
 ### Updated Cost of Storage
 
-\[
-\text{Updated Cost} = (TC - SP) \cdot \frac{S_r}{S_t}
-\]
+```
+Updated Cost = (TC - SP) * (S_r / S_t)
+```
 
-with total construction cost \(TC\), specific costs \(SP\), storage reallocated
-\(S_r\), and total usable storage \(S_t\).
+with total construction cost TC, specific costs SP, storage reallocated S_r, and
+total usable storage S_t.
 
 ### Interest During Construction (IDC)
 
-\[
-\text{IDC} = \sum_{i=1}^{m} C_i \cdot \frac{r}{12} \cdot t_i
-\]
+```
+IDC = sum from i = 1 to m of C_i * (r / 12) * t_i
+```
 
-where \(C_i\) is the cost incurred in month \(i\), \(r\) is the annual
-interest rate expressed as a decimal, \(m\) is the construction period in
-months, and \(t_i\) is the number of months the expenditure accrues interest.
-Beginning-, middle-, and end-of-month expenditures correspond to
-\(t_i = m - i + 1\), \(m - i + 0.5\), and \(m - i\), respectively. When costs
-are normalized across the construction period, \(C_i = T/m\) with the first
-month treated as a beginning-of-month expenditure and the remaining months at
-midpoints.
+where C_i is the cost incurred in month i, r is the annual interest rate
+expressed as a decimal, m is the construction period in months, and t_i is the
+number of months the expenditure accrues interest. Beginning-, middle-, and
+end-of-month expenditures correspond to t_i = m - i + 1, m - i + 0.5, and m - i,
+respectively. When costs are normalized across the construction period, C_i =
+T / m with the first month treated as a beginning-of-month expenditure and the
+remaining months at midpoints.
 
 ### Present Value of Planned Future Costs
 
-\[
-PV = C \cdot (1 + r)^{-(y - b)}
-\]
+```
+PV = C * (1 + r)^(-(y - b))
+```
 
-where \(C\) is a cost incurred in year \(y\), \(r\) is the discount rate, and
-\(b\) is the base year.
+where C is a cost incurred in year y, r is the discount rate, and b is the base
+year.
 
 ### Capital Recovery Factor (CRF)
 
-\[
-CRF = \frac{r(1 + r)^n}{(1 + r)^n - 1}
-\]
+```
+CRF = r * (1 + r)^n / ((1 + r)^n - 1)
+```
 
-for discount rate \(r\) and period of analysis \(n\) years. If \(r = 0\), then
-\(CRF = 1/n\).
+for discount rate r and period of analysis n years. If r = 0, then CRF = 1 / n.
 
 ### Annualized Costs and Benefit–Cost Ratio
 
-\[
-\begin{aligned}
-\text{Annual Construction} &= \text{Total Investment} \cdot CRF \\
-\text{Annual Total Cost} &= \text{Annual Construction} + \text{Annual O\&M} \\
-\text{Benefit–Cost Ratio} &= \frac{\text{Annual Benefits}}{\text{Annual Total Cost}}
-\end{aligned}
-\]
+```
+Annual Construction = Total Investment * CRF
+Annual Total Cost = Annual Construction + Annual O&M
+Benefit–Cost Ratio = Annual Benefits / Annual Total Cost
+```
 
 ## References
 


### PR DESCRIPTION
## Summary
- replace LaTeX-style notation with plain text formulas so they're easier to read
- use `*` for multiplication across economic equations in the README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a74d822e1c83309c3abbbf0101ec8d