### PR TITLE
Add recreation ranking conversion table

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Annual Recreation Benefit = UDV * User Days
 
 where UDV is the unit day value from the latest USACE schedule and User Days
 are the expected annual recreation visitations.
+The application converts recreation quality point rankings to unit day values
+using USACE schedules for general recreation, fishing and hunting, and other
+specialized activities such as boating.
 
 ## References
 


### PR DESCRIPTION
## Summary
- incorporate USACE point-to-dollar conversion table
- allow selecting activity type and convert ranking points to unit day values
- document point-based recreation benefit calculation

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba285a4b348330946ac73bce0de269