### PR TITLE
Add visitation multiplier to UDV analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,14 +87,16 @@ Benefit–Cost Ratio = Annual Benefits / Annual Total Cost
 ### Recreation Benefits via Unit Day Values
 
 ```
-Annual Recreation Benefit = UDV * User Days
+Adjusted User Days = User Days × Expected Visitation
+Annual Recreation Benefit = UDV × Adjusted User Days
 ```
 
-where UDV is the unit day value from the latest USACE schedule and User Days
-are the expected annual recreation visitations.
-The application converts recreation quality point rankings to unit day values
-using USACE schedules for general recreation, fishing and hunting, and other
-specialized activities such as boating.
+where UDV is the unit day value from the latest USACE schedule. User Days
+represent the expected annual recreation days, and Expected Visitation is
+applied as a multiplier to adjust the user day estimate. The application
+converts recreation quality point rankings to unit day values using USACE
+schedules for general recreation, fishing and hunting, and other specialized
+activities such as boating.
 
 ### Municipal and Industrial Water Demand Forecast
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -757,16 +757,27 @@ def udv_analysis():
             value=0.0,
             step=1.0,
         )
+        visitation = st.number_input(
+            "Expected Visitation",
+            min_value=0.0,
+            value=1.0,
+            step=1.0,
+            help="Multiplier applied to the expected annual user days.",
+        )
         if st.button("Compute Recreation Benefit"):
-            benefit = udv_value * user_days
+            total_user_days = user_days * visitation
+            benefit = udv_value * total_user_days
             st.success(f"Annual Recreation Benefit: ${benefit:,.2f}")
+            st.info(f"Adjusted Annual User Days: {total_user_days:,.2f}")
             st.session_state.udv_benefit = benefit
             st.session_state.udv_inputs = {
                 "Recreation Type": rec_type,
                 "Activity Type": activity,
                 "Point Value": points,
                 "Unit Day Value": udv_value,
-                "Annual User Days": user_days,
+                "Expected Annual User Days": user_days,
+                "Expected Visitation": visitation,
+                "Adjusted Annual User Days": total_user_days,
             }
     with tab_rank:
         st.subheader(


### PR DESCRIPTION
## Summary
- allow entering expected visitation and apply it as a multiplier to user days in the UDV calculator
- document adjusted user day computation in README

## Testing
- `python -m py_compile streamlit_app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bef65b1c3c8330856a30ff831cf189