### PR TITLE
Clarify water supply specific cost label

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -495,7 +495,7 @@ def storage_calculator():
             help="Total joint-use construction costs updated using CWCCIS and ENR.",
         )
         sp = st.number_input(
-            "Specific costs (SP)",
+            "Water Supply Specific Costs (SP)",
             min_value=0.0,
             value=100000.0,
             help="Costs of identifiable project features for a specific purpose, updated using CWCCIS and ENR.",
@@ -525,7 +525,7 @@ def storage_calculator():
         st.session_state.storage_cost = cost
         st.session_state.storage_inputs = {
             "Total Joint Use Construction Cost (TC)": tc,
-            "Specific costs (SP)": sp,
+            "Water Supply Specific Costs (SP)": sp,
             "Estimated Storage to be Reallocated (ac-ft)": storage_reallocated,
             "Total usable storage space (ac-ft)": total_usable_storage,
         }


### PR DESCRIPTION
## Summary
- Rename "Specific costs (SP)" to "Water Supply Specific Costs (SP)" in Updated Storage Cost calculator
- Ensure exported storage inputs use the updated label

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68beff72493c8330845fb16d9aef83a5