### PR TITLE
Replace deprecated use_container_width in Streamlit data editors

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -452,7 +452,7 @@ def ead_calculator():
         data = st.data_editor(
             st.session_state.table,
             num_rows="dynamic",
-            use_container_width=True,
+            width="stretch",
             key="table_editor",
             column_config=column_config,
         )
@@ -672,7 +672,7 @@ def storage_calculator():
         raw_table = st.data_editor(
             st.session_state.usc_table,
             num_rows="dynamic",
-            use_container_width=True,
+            width="stretch",
             column_config=usc_cols,
             key="usc_table_editor",
         )
@@ -739,7 +739,7 @@ def storage_calculator():
         raw_costs = st.data_editor(
             st.session_state.rrr_costs,
             num_rows="dynamic",
-            use_container_width=True,
+            width="stretch",
             column_config=cost_cols,
             key="rrr_costs_editor",
         )


### PR DESCRIPTION
## Summary
- replace `use_container_width=True` with `width='stretch'` in `st.data_editor` calls to comply with Streamlit deprecation warning

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest; apt-get update 403 errors when trying to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bf44bc0f108330995527934099082f