### PR TITLE
fix: scale O&M and RR&R by storage percentage

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -284,6 +284,8 @@ def build_excel():
         ctot = updated_storage.get("CTot") if updated_storage else None
         om_total = joint_om.get("total") if joint_om else None
         rrr_annual = rrr_mit.get("annualized") if rrr_mit else None
+        om_scaled = om_total * p if None not in (om_total, p) else None
+        rrr_scaled = rrr_annual * p if None not in (rrr_annual, p) else None
 
         drate1 = total_inputs.get("rate1") if total_inputs else None
         years1 = total_inputs.get("periods1") if total_inputs else None
@@ -306,10 +308,10 @@ def build_excel():
             ws_tac.append(["Cost of Storage Recommendation", crec, crec])
         if cap1 is not None or cap2 is not None:
             ws_tac.append(["Annualized Storage Cost", cap1, cap2])
-        if om_total is not None:
-            ws_tac.append(["Joint O&M", om_total, om_total])
-        if rrr_annual is not None:
-            ws_tac.append(["Annualized RR&R/Mitigation", rrr_annual, rrr_annual])
+        if om_scaled is not None:
+            ws_tac.append(["Joint O&M", om_scaled, om_scaled])
+        if rrr_scaled is not None:
+            ws_tac.append(["Annualized RR&R/Mitigation", rrr_scaled, rrr_scaled])
         if isinstance(storage_costs, dict):
             ws_tac.append(
                 [
@@ -794,6 +796,8 @@ def storage_calculator():
         ctot = st.session_state.get("updated_storage", {}).get("CTot", 0.0)
         om_total = st.session_state.get("joint_om", {}).get("total", 0.0)
         rrr_annual = st.session_state.get("rrr_mit", {}).get("annualized", 0.0)
+        om_scaled = om_total * p
+        rrr_scaled = rrr_annual * p
         crec = ctot * p
 
         st.session_state.setdefault("total_annual_cost_inputs", {})
@@ -824,12 +828,12 @@ def storage_calculator():
                 help="Number of years over which storage costs are annualized.",
             )
             capital1 = ctot * p * capital_recovery_factor(drate1 / 100.0, years1)
-            total1 = capital1 + om_total + rrr_annual
+            total1 = capital1 + om_scaled + rrr_scaled
             st.metric("Percent of Total Conservation Storage (P)", f"{p:.5f}")
             st.metric("Cost of Storage Recommendation", f"${crec:,.2f}")
             st.metric("Annualized Storage Cost", f"${capital1:,.2f}")
-            st.metric("Joint O&M", f"${om_total:,.2f}")
-            st.metric("Annualized RR&R/Mitigation", f"${rrr_annual:,.2f}")
+            st.metric("Joint O&M", f"${om_scaled:,.2f}")
+            st.metric("Annualized RR&R/Mitigation", f"${rrr_scaled:,.2f}")
             st.metric("Total Annual Cost", f"${total1:,.2f}")
 
         with col2:
@@ -855,12 +859,12 @@ def storage_calculator():
                 help="Number of years over which storage costs are annualized.",
             )
             capital2 = ctot * p * capital_recovery_factor(drate2 / 100.0, years2)
-            total2 = capital2 + om_total + rrr_annual
+            total2 = capital2 + om_scaled + rrr_scaled
             st.metric("Percent of Total Conservation Storage (P)", f"{p:.5f}")
             st.metric("Cost of Storage Recommendation", f"${crec:,.2f}")
             st.metric("Annualized Storage Cost", f"${capital2:,.2f}")
-            st.metric("Joint O&M", f"${om_total:,.2f}")
-            st.metric("Annualized RR&R/Mitigation", f"${rrr_annual:,.2f}")
+            st.metric("Joint O&M", f"${om_scaled:,.2f}")
+            st.metric("Annualized RR&R/Mitigation", f"${rrr_scaled:,.2f}")
             st.metric("Total Annual Cost", f"${total2:,.2f}")
 
         st.session_state.total_annual_cost_inputs = {

--- a/tests/test_excel_export.py
+++ b/tests/test_excel_export.py
@@ -92,5 +92,11 @@ def test_build_excel_includes_storage_sheets():
     assert ws_tac["A3"].value == "Cost of Storage Recommendation"
     assert ws_tac["B3"].value == 1.5
     assert ws_tac["C3"].value == 1.5
+    assert ws_tac["A5"].value == "Joint O&M"
+    assert ws_tac["B5"].value == 7.5
+    assert ws_tac["C5"].value == 7.5
+    assert ws_tac["A6"].value == "Annualized RR&R/Mitigation"
+    assert ws_tac["B6"].value == 5.0
+    assert ws_tac["C6"].value == 5.0
     assert ws_tac["B7"].value == 25.0
     assert ws_tac["C7"].value == 30.0


### PR DESCRIPTION
## Summary
- Scale joint O&M and RR&R/mitigation totals by the percentage of storage reallocated
- Apply same scaling in Excel export and add regression test for scaled values

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf529138ec8330b9255cf4a8f8e44a