### PR TITLE
Remove duplicate lines from Total Annual Cost

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -284,7 +284,6 @@ def build_excel():
         ctot = updated_storage.get("CTot") if updated_storage else None
         om_total = joint_om.get("total") if joint_om else None
         rrr_annual = rrr_mit.get("annualized") if rrr_mit else None
-        rrr_share = rrr_annual * p if None not in (rrr_annual, p) else None
         om_scaled = om_total * p if None not in (om_total, p) else None
         rrr_scaled = rrr_annual * p if None not in (rrr_annual, p) else None
 
@@ -309,16 +308,6 @@ def build_excel():
             ws_tac.append(["Cost of Storage Recommendation", crec, crec])
         if cap1 is not None or cap2 is not None:
             ws_tac.append(["Annualized Storage Cost", cap1, cap2])
-        if om_total is not None:
-            ws_tac.append(["Joint O&M", om_total, om_total])
-        if rrr_share is not None:
-            ws_tac.append(
-                [
-                    "Annual Replacement and Rehabilitation Estimate",
-                    rrr_share,
-                    rrr_share,
-                ]
-            )
         if om_scaled is not None:
             ws_tac.append(["Joint O&M", om_scaled, om_scaled])
         if rrr_scaled is not None:
@@ -807,7 +796,6 @@ def storage_calculator():
         ctot = st.session_state.get("updated_storage", {}).get("CTot", 0.0)
         om_total = st.session_state.get("joint_om", {}).get("total", 0.0)
         rrr_annual = st.session_state.get("rrr_mit", {}).get("annualized", 0.0)
-        rrr_share = rrr_annual * p
         om_scaled = om_total * p
         rrr_scaled = rrr_annual * p
         crec = ctot * p
@@ -840,15 +828,6 @@ def storage_calculator():
                 help="Number of years over which storage costs are annualized.",
             )
             capital1 = ctot * p * capital_recovery_factor(drate1 / 100.0, years1)
-            total1 = capital1 + om_total + rrr_share
-            st.metric("Percent of Total Conservation Storage (P)", f"{p:.5f}")
-            st.metric("Cost of Storage Recommendation", f"${crec:,.2f}")
-            st.metric("Annualized Storage Cost", f"${capital1:,.2f}")
-            st.metric("Joint O&M", f"${om_total:,.2f}")
-            st.metric(
-                "Annual Replacement and Rehabilitation Estimate",
-                f"${rrr_share:,.2f}",
-            )
             total1 = capital1 + om_scaled + rrr_scaled
             st.metric("Percent of Total Conservation Storage (P)", f"{p:.5f}")
             st.metric("Cost of Storage Recommendation", f"${crec:,.2f}")
@@ -880,15 +859,6 @@ def storage_calculator():
                 help="Number of years over which storage costs are annualized.",
             )
             capital2 = ctot * p * capital_recovery_factor(drate2 / 100.0, years2)
-            total2 = capital2 + om_total + rrr_share
-            st.metric("Percent of Total Conservation Storage (P)", f"{p:.5f}")
-            st.metric("Cost of Storage Recommendation", f"${crec:,.2f}")
-            st.metric("Annualized Storage Cost", f"${capital2:,.2f}")
-            st.metric("Joint O&M", f"${om_total:,.2f}")
-            st.metric(
-                "Annual Replacement and Rehabilitation Estimate",
-                f"${rrr_share:,.2f}",
-            )
             total2 = capital2 + om_scaled + rrr_scaled
             st.metric("Percent of Total Conservation Storage (P)", f"{p:.5f}")
             st.metric("Cost of Storage Recommendation", f"${crec:,.2f}")

--- a/tests/test_excel_export.py
+++ b/tests/test_excel_export.py
@@ -61,9 +61,10 @@ def test_build_excel_includes_storage_sheets():
     inputs = st.session_state.total_annual_cost_inputs
     cap1 = ctot * p * capital_recovery_factor(inputs["rate1"] / 100.0, inputs["periods1"])
     cap2 = ctot * p * capital_recovery_factor(inputs["rate2"] / 100.0, inputs["periods2"])
-    rrr_share = st.session_state.rrr_mit["annualized"] * p
-    total1 = cap1 + st.session_state.joint_om["total"] + rrr_share
-    total2 = cap2 + st.session_state.joint_om["total"] + rrr_share
+    om_scaled = st.session_state.joint_om["total"] * p
+    rrr_scaled = st.session_state.rrr_mit["annualized"] * p
+    total1 = cap1 + om_scaled + rrr_scaled
+    total2 = cap2 + om_scaled + rrr_scaled
     st.session_state.storage_cost = {"scenario1": total1, "scenario2": total2}
 
     buffer = build_excel()
@@ -99,18 +100,25 @@ def test_build_excel_includes_storage_sheets():
     ws_tac = wb["Total Annual Cost"]
     assert ws_tac["A2"].value == "Percent of Total Conservation Storage (P)"
     assert ws_tac["A3"].value == "Cost of Storage Recommendation"
+    assert ws_tac["A4"].value == "Annualized Storage Cost"
+    assert ws_tac["A5"].value == "Joint O&M"
+    assert ws_tac["A6"].value == "Annualized RR&R/Mitigation"
+    assert ws_tac["A7"].value == "Total Annual Cost"
+    assert ws_tac["B2"].value == 0.5
+    assert ws_tac["C2"].value == 0.5
     assert ws_tac["B3"].value == 1.5
     assert ws_tac["C3"].value == 1.5
-    assert ws_tac["A6"].value == "Annual Replacement and Rehabilitation Estimate"
-    assert ws_tac["B6"].value == pytest.approx(rrr_share)
-    assert ws_tac["C6"].value == pytest.approx(rrr_share)
+    assert ws_tac["B4"].value == pytest.approx(cap1)
+    assert ws_tac["C4"].value == pytest.approx(cap2)
+    assert ws_tac["B5"].value == pytest.approx(om_scaled)
+    assert ws_tac["C5"].value == pytest.approx(om_scaled)
+    assert ws_tac["B6"].value == pytest.approx(rrr_scaled)
+    assert ws_tac["C6"].value == pytest.approx(rrr_scaled)
     assert ws_tac["B7"].value == pytest.approx(total1)
     assert ws_tac["C7"].value == pytest.approx(total2)
-    assert ws_tac["A5"].value == "Joint O&M"
-    assert ws_tac["B5"].value == 7.5
-    assert ws_tac["C5"].value == 7.5
-    assert ws_tac["A6"].value == "Annualized RR&R/Mitigation"
-    assert ws_tac["B6"].value == 5.0
-    assert ws_tac["C6"].value == 5.0
-    assert ws_tac["B7"].value == 25.0
-    assert ws_tac["C7"].value == 30.0
+    assert ws_tac["A8"].value == "Discount Rate (%) for Storage Cost"
+    assert ws_tac["B8"].value == 5.0
+    assert ws_tac["C8"].value == 6.0
+    assert ws_tac["A9"].value == "Analysis Period (years)"
+    assert ws_tac["B9"].value == 30
+    assert ws_tac["C9"].value == 40


### PR DESCRIPTION
## Summary
- Simplify Total Annual Cost subtab by computing totals once and displaying scaled Joint O&M and RR&R/Mitigation values.
- Update Excel export to omit duplicate unscaled lines and reflect scaled metrics only.
- Adjust unit tests to match the streamlined Total Annual Cost output.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf5e313ba88330950acb318195f2b9