### PR TITLE
Exclude RR&R from second cost scenario and preset analysis periods

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -285,7 +285,7 @@ def build_excel():
         om_total = joint_om.get("total") if joint_om else None
         rrr_annual = rrr_mit.get("annualized") if rrr_mit else None
         om_scaled = om_total * p if None not in (om_total, p) else None
-        rrr_scaled = rrr_annual * p if None not in (rrr_annual, p) else None
+        rrr_scaled1 = rrr_annual * p if None not in (rrr_annual, p) else None
 
         drate1 = total_inputs.get("rate1") if total_inputs else None
         years1 = total_inputs.get("periods1") if total_inputs else None
@@ -310,8 +310,8 @@ def build_excel():
             ws_tac.append(["Annualized Storage Cost", cap1, cap2])
         if om_scaled is not None:
             ws_tac.append(["Joint O&M", om_scaled, om_scaled])
-        if rrr_scaled is not None:
-            ws_tac.append(["Annualized RR&R/Mitigation", rrr_scaled, rrr_scaled])
+        if rrr_scaled1 is not None:
+            ws_tac.append(["Annualized RR&R/Mitigation", rrr_scaled1, 0.0])
         if isinstance(storage_costs, dict):
             ws_tac.append(
                 [
@@ -798,6 +798,7 @@ def storage_calculator():
         rrr_annual = st.session_state.get("rrr_mit", {}).get("annualized", 0.0)
         om_scaled = om_total * p
         rrr_scaled = rrr_annual * p
+        rrr_scaled2 = 0.0
         crec = ctot * p
 
         st.session_state.setdefault("total_annual_cost_inputs", {})
@@ -819,11 +820,7 @@ def storage_calculator():
                 "Analysis Period (years)",
                 min_value=1,
                 step=1,
-                value=int(
-                    inputs.get(
-                        "periods1", st.session_state.rrr_mit.get("periods", 30)
-                    )
-                ),
+                value=int(inputs.get("periods1", 30)),
                 key="tac_years1",
                 help="Number of years over which storage costs are annualized.",
             )
@@ -850,21 +847,17 @@ def storage_calculator():
                 "Analysis Period (years)",
                 min_value=1,
                 step=1,
-                value=int(
-                    inputs.get(
-                        "periods2", st.session_state.rrr_mit.get("periods", 30)
-                    )
-                ),
+                value=int(inputs.get("periods2", 50)),
                 key="tac_years2",
                 help="Number of years over which storage costs are annualized.",
             )
             capital2 = ctot * p * capital_recovery_factor(drate2 / 100.0, years2)
-            total2 = capital2 + om_scaled + rrr_scaled
+            total2 = capital2 + om_scaled
             st.metric("Percent of Total Conservation Storage (P)", f"{p:.5f}")
             st.metric("Cost of Storage Recommendation", f"${crec:,.2f}")
             st.metric("Annualized Storage Cost", f"${capital2:,.2f}")
             st.metric("Joint O&M", f"${om_scaled:,.2f}")
-            st.metric("Annualized RR&R/Mitigation", f"${rrr_scaled:,.2f}")
+            st.metric("Annualized RR&R/Mitigation", f"${rrr_scaled2:,.2f}")
             st.metric("Total Annual Cost", f"${total2:,.2f}")
 
         st.session_state.total_annual_cost_inputs = {

--- a/tests/test_excel_export.py
+++ b/tests/test_excel_export.py
@@ -64,7 +64,7 @@ def test_build_excel_includes_storage_sheets():
     om_scaled = st.session_state.joint_om["total"] * p
     rrr_scaled = st.session_state.rrr_mit["annualized"] * p
     total1 = cap1 + om_scaled + rrr_scaled
-    total2 = cap2 + om_scaled + rrr_scaled
+    total2 = cap2 + om_scaled
     st.session_state.storage_cost = {"scenario1": total1, "scenario2": total2}
 
     buffer = build_excel()
@@ -113,7 +113,7 @@ def test_build_excel_includes_storage_sheets():
     assert ws_tac["B5"].value == pytest.approx(om_scaled)
     assert ws_tac["C5"].value == pytest.approx(om_scaled)
     assert ws_tac["B6"].value == pytest.approx(rrr_scaled)
-    assert ws_tac["C6"].value == pytest.approx(rrr_scaled)
+    assert ws_tac["C6"].value == 0
     assert ws_tac["B7"].value == pytest.approx(total1)
     assert ws_tac["C7"].value == pytest.approx(total2)
     assert ws_tac["A8"].value == "Discount Rate (%) for Storage Cost"


### PR DESCRIPTION
## Summary
- Auto-populate analysis periods in total annual cost calculator (30 years for scenario 1, 50 years for scenario 2)
- Omit RR&R/mitigation costs from scenario 2's total annual cost and workbook export
- Update tests to reflect new scenario 2 calculation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf60b2f8f88330b4ba131d3ae9f25d