### PR TITLE
Add persistent data editor helper

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,3 +1,4 @@
+import copy
 import streamlit as st
 import numpy as np
 import pandas as pd
@@ -80,8 +81,8 @@ def persistent_data_editor(df: pd.DataFrame, key: str, **kwargs) -> pd.DataFrame
     ensures that all edits persist immediately.
     """
 
-    edited = st.data_editor(df.copy(deep=True), key=key, **kwargs)
-    return edited.copy(deep=True)
+    edited = st.data_editor(copy.deepcopy(df), key=key, **kwargs)
+    return copy.deepcopy(edited)
 
 
 def ead_trapezoidal(prob, damages):

--- a/tests/test_persistent_editor.py
+++ b/tests/test_persistent_editor.py
@@ -1,0 +1,29 @@
+import pandas as pd
+import streamlit as st
+import streamlit_app
+
+
+def test_persistent_data_editor_returns_deep_copies(monkeypatch):
+    # Track the id of the object passed to the mock data_editor
+    recorded = {}
+
+    def mock_data_editor(df, key, **kwargs):
+        # simulate user editing by mutating the provided df in place
+        df.loc[0, "a"] = 2
+        recorded["id"] = id(df)
+        return df
+
+    monkeypatch.setattr(st, "data_editor", mock_data_editor)
+
+    original = pd.DataFrame({"a": [1]})
+    edited = streamlit_app.persistent_data_editor(original, key="test")
+
+    # original should remain unchanged
+    assert original.loc[0, "a"] == 1
+    # edit is applied in returned dataframe
+    assert edited.loc[0, "a"] == 2
+    # returned object should not be the same as the one passed to data_editor
+    assert id(edited) != recorded["id"]
+    # modifying the returned dataframe shouldn't affect the original
+    edited.loc[0, "a"] = 3
+    assert original.loc[0, "a"] == 1


### PR DESCRIPTION
## Summary
- deep copy DataFrames before and after `st.data_editor` to prevent loss of first edits
- add regression test for `persistent_data_editor`

## Testing
- `pytest -q`
- `streamlit run streamlit_app.py` *(server starts)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6968f7ac8330b969149402c93c2c