### PR TITLE
Add desktop Tkinter interface and core toolbox module

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ streamlit run streamlit_app.py
 
 Every tab stores its inputs in the session state so results can be exported or revisited later in the session.
 
+### Desktop App
+
+A minimal desktop interface is provided for exploratory use without Streamlit:
+
+```bash
+python desktop_app.py
+```
+
+The script opens a small Tkinter window that computes the capital recovery factor.
+
 ---
 
 ## Tab Reference

--- a/desktop_app.py
+++ b/desktop_app.py
@@ -1,0 +1,36 @@
+import tkinter as tk
+from tkinter import ttk, messagebox
+from toolbox import capital_recovery_factor
+
+
+class EconToolboxApp(tk.Tk):
+    """Simple desktop interface for core toolbox calculations."""
+
+    def __init__(self):
+        super().__init__()
+        self.title("Economic Toolbox Desktop")
+        self.geometry("360x160")
+
+        ttk.Label(self, text="Rate (%)").grid(row=0, column=0, padx=5, pady=5, sticky="w")
+        self.rate_var = tk.DoubleVar(value=5.0)
+        ttk.Entry(self, textvariable=self.rate_var).grid(row=0, column=1, padx=5, pady=5)
+
+        ttk.Label(self, text="Periods").grid(row=1, column=0, padx=5, pady=5, sticky="w")
+        self.periods_var = tk.IntVar(value=10)
+        ttk.Entry(self, textvariable=self.periods_var).grid(row=1, column=1, padx=5, pady=5)
+
+        ttk.Button(self, text="Compute CRF", command=self.compute).grid(
+            row=2, column=0, columnspan=2, pady=10
+        )
+
+    def compute(self):
+        """Calculate and display the capital recovery factor."""
+        rate = self.rate_var.get() / 100.0
+        periods = self.periods_var.get()
+        crf = capital_recovery_factor(rate, periods)
+        messagebox.showinfo("Result", f"Capital recovery factor: {crf:.6f}")
+
+
+if __name__ == "__main__":
+    app = EconToolboxApp()
+    app.mainloop()

--- a/toolbox.py
+++ b/toolbox.py
@@ -1,0 +1,64 @@
+import numpy as np
+
+
+def ead_trapezoidal(prob, damages):
+    """Return expected annual damage via trapezoidal integration."""
+    prob = np.asarray(prob, dtype=float)
+    damages = np.asarray(damages, dtype=float)
+    return float(np.sum(0.5 * (damages[:-1] + damages[1:]) * (prob[:-1] - prob[1:])))
+
+
+def updated_storage_cost(tc, sp, storage_reallocated, total_usable_storage):
+    """Compute updated cost of storage for reservoir reallocations."""
+    tc = float(tc)
+    sp = float(sp)
+    storage_reallocated = float(storage_reallocated)
+    total_usable_storage = float(total_usable_storage)
+    return (tc - sp) * storage_reallocated / total_usable_storage
+
+
+def interest_during_construction(
+    total_initial_cost,
+    rate,
+    months,
+    *,
+    costs=None,
+    timings=None,
+    normalize=True,
+):
+    """Compute interest during construction (IDC)."""
+    if months <= 0:
+        return 0.0
+
+    monthly_rate = rate / 12.0
+
+    if costs is None:
+        if not normalize:
+            years = months / 12.0
+            return total_initial_cost * rate * years / 8
+
+        monthly_cost = total_initial_cost / months
+        costs = [monthly_cost] * months
+        timings = ["beginning"] + ["middle"] * (months - 1)
+    else:
+        if timings is None:
+            timings = ["middle"] * len(costs)
+
+    idc = 0.0
+    for i, cost in enumerate(costs, start=1):
+        timing = timings[i - 1]
+        if timing == "beginning":
+            remaining = months - i + 1
+        elif timing == "end":
+            remaining = months - i
+        else:  # middle
+            remaining = months - i + 0.5
+        idc += cost * monthly_rate * remaining
+    return idc
+
+
+def capital_recovery_factor(rate, periods):
+    """Return capital recovery factor for a given discount rate and period."""
+    if rate == 0:
+        return 1 / periods
+    return rate * (1 + rate) ** periods / ((1 + rate) ** periods - 1)


### PR DESCRIPTION
## Summary
- Add `toolbox.py` with reusable economic-engineering formulas
- Introduce a Tkinter-based `desktop_app.py` for offline usage
- Document the new desktop interface in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0569e9d788330894b33c903c2636e