### PR TITLE
Allow editing of UDV schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ where \(u_t\) is per-capita municipal use (adjusted for conservation), \(f_t\) i
 
 - **Storage Cost and O&M:** Cost update factors and CWCCI ratios must be entered manually; automatic retrieval from current indices would reduce errors.
 - **Project Cost Annualizer:** IDC calculation requires monthly detail when costs are irregular; importing a schedule from CSV would streamline entry.
-- **Recreation Benefit:** UDV schedules are hard-coded for a single fiscal year; updating values when new schedules are released is manual.
+- **Recreation Benefit:** UDV schedules default to a single fiscal year; use the editable table in the UDV tab to update values when new schedules are released.
 - **Water Demand Forecast:** Supports year-specific growth, industrial demand, conservation, and loss factors. Scenario analysis or probabilistic inputs could further enhance realism.
 
 ---

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -9,8 +9,8 @@ from openpyxl import Workbook
 from openpyxl.utils.dataframe import dataframe_to_rows
 from openpyxl.chart import LineChart, Reference
 
-# Conversion table from point rankings to unit day values ($/user day)
-POINT_VALUE_TABLE = pd.DataFrame(
+# Default conversion table from point rankings to unit day values ($/user day)
+DEFAULT_UDV_TABLE = pd.DataFrame(
     {
         "Points": [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
         "General Recreation": [
@@ -1113,6 +1113,9 @@ def udv_analysis():
     st.info(
         "Estimate annual recreation benefits using USACE Unit Day Values (UDV).",
     )
+    if "udv_table" not in st.session_state:
+        st.session_state.udv_table = DEFAULT_UDV_TABLE.copy()
+    udv_table = st.session_state.udv_table
     tab_calc, tab_rank = st.tabs(["Calculator", "Ranking Criteria"])
     with tab_calc:
         rec_type = st.selectbox(
@@ -1149,7 +1152,9 @@ def udv_analysis():
         table_col = column_map[(rec_type, activity)]
         udv_calc = float(
             np.interp(
-                points, POINT_VALUE_TABLE["Points"], POINT_VALUE_TABLE[table_col]
+                points,
+                udv_table["Points"],
+                udv_table[table_col],
             )
         )
         udv_value = st.number_input(
@@ -1236,7 +1241,11 @@ def udv_analysis():
         }
         st.table(pd.DataFrame(criteria_table).set_index("Criteria"))
         st.subheader("Table 2. Conversion of Points to Dollar Values")
-        st.table(POINT_VALUE_TABLE.set_index("Points"))
+        st.session_state.udv_table = persistent_data_editor(
+            st.session_state.udv_table,
+            key="udv_table_editor",
+            num_rows="dynamic",
+        )
     export_button()
 
 


### PR DESCRIPTION
## Summary
- Replace hard-coded UDV schedule with editable table backed by Streamlit session state
- Document that UDV schedule can be updated directly in the app

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0a600ee908330a592d8fd2093be16